### PR TITLE
Fix build for nightly rustc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,10 @@
 #![feature(box_syntax)]
 #![feature(box_patterns)]
 #![feature(rustc_private)]
-#![feature(core)]
+#![feature(core_intrinsics)]
 #![feature(str_char)]
 #![feature(unicode)]
+#![allow(raw_pointer_derive)]
 
 // TODO use crates.io log instead
 #[macro_use]


### PR DESCRIPTION
This silences the error:

```
error: use of unstable library feature 'core_intrinsics': intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
```

and the warning

```
warning: use of `#[derive]` with a raw pointer, #[warn(raw_pointer_derive)] on by default
```

Unfortunately, it does not mention what stable interfaces we could use specifically instead of `::std::intrinsics::volatile_copy_nonoverlapping_memory`...
