### PR TITLE
Remove patch specification in log dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ name = "strings"
 path = "src/lib.rs"
 
 [dependencies]
-log = "0.3.2"
+log = "0.3"


### PR DESCRIPTION
The specific pinning of that dependency is causing issues with crates
that depend on more recent version of log.
