### PR TITLE
Refactor ropes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,15 @@
 extern crate log;
 
 // TODO should probably expose data structures, not the modules
-pub mod rope;
-pub mod src_rope;
 pub mod string_buffer;
+
 mod util;
+mod ropes;
+
+pub mod rope {
+    pub use ::ropes::Rope;
+}
+
+pub mod src_rope {
+    pub use ::ropes::SrcRope as Rope;
+}

--- a/src/ropes/macros.rs
+++ b/src/ropes/macros.rs
@@ -1,0 +1,97 @@
+/// Generate implementation of common methods shared between
+/// both Rope variants (rope & src_rope).
+macro_rules! impl_rope {
+    ($ty: ty) => {
+        impl $ty {
+            pub fn len(&self) -> usize {
+                self.len
+            }
+
+            pub fn insert_copy(&mut self, start: usize, text: &str) {
+                // FIXME If we did clever things with allocation, we could do better here.
+                self.insert(start, text.to_string());
+            }
+
+            pub fn push(&mut self, text: String) {
+                let len = self.len();
+                self.insert(len, text);
+            }
+
+            pub fn push_copy(&mut self, text: &str) {
+                // If we did clever things with allocation, we could do better here
+                let len = self.len();
+                self.insert(len, text.to_string());
+            }
+
+            fn remove_inner<F>(&mut self,
+                               start: usize,
+                               end: usize,
+                               do_remove: F)
+                where F: Fn(&mut Rope) -> NodeAction
+            {
+                assert!(end >= start);
+                if start == end {
+                    return;
+                }
+
+                match do_remove(self) {
+                    NodeAction::None => {}
+                    NodeAction::Remove => {
+                        self.root = Node::empty_inner();
+                        self.len = 0;
+                    }
+                    NodeAction::Adjust(adj) => self.len = (self.len as isize + adj) as usize,
+                    NodeAction::Change(node, adj) => {
+                        self.root = *node;
+                        self.len = (self.len as isize + adj) as usize;
+                    }
+                }
+            }
+
+            // This can go horribly wrong if you overwrite a grapheme of different size.
+            // It is the callers responsibility to ensure that the grapheme at point start
+            // has the same size as new_char.
+            pub fn replace(&mut self, start: usize, new_char: char) {
+                assert!(start + new_char.len_utf8() <= self.len);
+                // This is pretty wasteful in that we're allocating for no point, but
+                // I think that is better than duplicating a bunch of code.
+                // It should be possible to view a &char as a &[u8] somehow, and then
+                // we can optimise this (FIXME).
+                self.replace_str(start, &new_char.to_string()[..]);
+            }
+
+            pub fn replace_str(&mut self, start: usize, new_str: &str) {
+                assert!(start + new_str.len() <= self.len);
+                self.root.replace(start, new_str);
+            }
+
+            pub fn slice(&self, Range { start, end }: Range<usize>) -> RopeSlice {
+                // This could be true for two cases
+                //    1. The Rope is empty (start == end == self.len == 0)
+                //    2. Attempting to slice the end of the rope (start == end == self.len)
+                if start == end {
+                    return RopeSlice::empty();
+                }
+
+                debug_assert!(end > start && start <= self.len && end <= self.len);
+
+                let mut result = RopeSlice::empty();
+                self.root.find_slice(start, end, &mut result);
+                result
+            }
+
+            pub fn full_slice(&self) -> RopeSlice {
+                self.slice(0..self.len)
+            }
+
+            pub fn chars(&self) -> RopeChars {
+                RopeChars {
+                    data: self.full_slice(),
+                    cur_node: 0,
+                    cur_byte: 0,
+                    abs_byte: 0,
+                }
+            }
+        }
+    }
+}

--- a/src/ropes/mod.rs
+++ b/src/ropes/mod.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+mod macros;
+
+mod rope;
+mod src_rope;
+
+pub use self::rope::Rope;
+pub use self::src_rope::Rope as SrcRope;

--- a/src/ropes/rope.rs
+++ b/src/ropes/rope.rs
@@ -53,6 +53,9 @@ pub struct RopeChars<'rope> {
     abs_byte: usize,
 }
 
+
+impl_rope!(Rope);
+
 impl Rope {
     // Create an empty rope.
     pub fn new() -> Rope {
@@ -70,16 +73,6 @@ impl Rope {
         let mut result = Rope::new();
         result.insert(0, text);
         result
-    }
-
-    // Length of the rope.
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    pub fn insert_copy(&mut self, start: usize, text: &str) {
-        // FIXME If we did clever things with allocation, we could do better here.
-        self.insert(start, text.to_string());
     }
 
     pub fn insert(&mut self, start: usize, text: String) {
@@ -118,89 +111,8 @@ impl Rope {
         self.len += len;
     }
 
-    pub fn push(&mut self, text: String) {
-        let len = self.len();
-        self.insert(len, text);
-    }
-
-    pub fn push_copy(&mut self, text: &str) {
-        // If we did clever things with allocation, we could do better here
-        let len = self.len();
-        self.insert(len, text.to_string());
-    }
-
     pub fn remove(&mut self, start: usize, end: usize) {
         self.remove_inner(start, end, |this| this.root.remove(start, end))
-    }
-
-    fn remove_inner<F>(&mut self,
-                       start: usize,
-                       end: usize,
-                       do_remove: F)
-        where F: Fn(&mut Rope) -> NodeAction
-    {
-        assert!(end >= start);
-        if start == end {
-            return;
-        }
-
-        match do_remove(self) {
-            NodeAction::None => {}
-            NodeAction::Remove => {
-                self.root = Node::empty_inner();
-                self.len = 0;
-            }
-            NodeAction::Adjust(adj) => self.len = (self.len as isize + adj) as usize,
-            NodeAction::Change(node, adj) => {
-                self.root = *node;
-                self.len = (self.len as isize + adj) as usize;
-            }
-        }
-    }
-
-    // This can go horribly wrong if you overwrite a grapheme of different size.
-    // It is the callers responsibility to ensure that the grapheme at point start
-    // has the same size as new_char.
-    pub fn replace(&mut self, start: usize, new_char: char) {
-        assert!(start + new_char.len_utf8() <= self.len);
-        // This is pretty wasteful in that we're allocating for no point, but
-        // I think that is better than duplicating a bunch of code.
-        // It should be possible to view a &char as a &[u8] somehow, and then
-        // we can optimise this (FIXME).
-        self.replace_str(start, &new_char.to_string()[..]);
-    }
-
-    pub fn replace_str(&mut self, start: usize, new_str: &str) {
-        assert!(start + new_str.len() <= self.len);
-        self.root.replace(start, new_str);
-    }
-
-    pub fn slice(&self, Range { start, end }: Range<usize>) -> RopeSlice {
-        // This could be true for two cases
-        //    1. The Rope is empty (start == end == self.len == 0)
-        //    2. Attempting to slice the end of the rope (start == end == self.len)
-        if start == end {
-            return RopeSlice::empty();
-        }
-
-        debug_assert!(end > start && start <= self.len && end <= self.len);
-
-        let mut result = RopeSlice::empty();
-        self.root.find_slice(start, end, &mut result);
-        result
-    }
-
-    pub fn full_slice(&self) -> RopeSlice {
-        self.slice(0..self.len)
-    }
-
-    pub fn chars(&self) -> RopeChars {
-        RopeChars {
-            data: self.full_slice(),
-            cur_node: 0,
-            cur_byte: 0,
-            abs_byte: 0,
-        }
     }
 }
 

--- a/src/ropes/src_rope.rs
+++ b/src/ropes/src_rope.rs
@@ -55,6 +55,8 @@ pub struct RopeChars<'rope> {
     abs_byte: usize,
 }
 
+impl_rope!(Rope);
+
 impl Rope {
     // Create an empty rope.
     pub fn new() -> Rope {
@@ -81,16 +83,6 @@ impl Rope {
     fn fix_src(&mut self) {
         self.root.fix_src();
         self.src_len = self.len;
-    }
-
-    // Length of the rope.
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    pub fn insert_copy(&mut self, start: usize, text: &str) {
-        // FIXME If we did clever things with allocation, we could do better here.
-        self.insert(start, text.to_string());
     }
 
     pub fn insert(&mut self, start: usize, text: String) {
@@ -135,17 +127,6 @@ impl Rope {
         self.len += len;
     }
 
-    pub fn push(&mut self, text: String) {
-        let len = self.len();
-        self.insert(len, text);
-    }
-
-    pub fn push_copy(&mut self, text: &str) {
-        // If we did clever things with allocation, we could do better here
-        let len = self.len();
-        self.insert(len, text.to_string());
-    }
-
     pub fn remove(&mut self, start: usize, end: usize) {
         self.remove_inner(start, end, |this| this.root.remove(start, end, start))
     }
@@ -154,50 +135,9 @@ impl Rope {
         self.remove_inner(start, end, |this| this.root.src_remove(start, end, start))
     }
 
-    fn remove_inner<F>(&mut self,
-                       start: usize,
-                       end: usize,
-                       do_remove: F)
-        where F: Fn(&mut Rope) -> NodeAction
-    {
-        assert!(end >= start);
-        if start == end {
-            return;
-        }
-
-        match do_remove(self) {
-            NodeAction::None => {}
-            NodeAction::Remove => {
-                self.root = Node::empty_inner();
-                self.len = 0;
-            }
-            NodeAction::Adjust(adj) => self.len = (self.len as isize + adj) as usize,
-            NodeAction::Change(node, adj) => {
-                self.root = *node;
-                self.len = (self.len as isize + adj) as usize;
-            }
-        }
-    }
 
     // TODO src_replace
     // TODO src_replace_str
-
-    // This can go horribly wrong if you overwrite a grapheme of different size.
-    // It is the callers responsibility to ensure that the grapheme at point start
-    // has the same size as new_char.
-    pub fn replace(&mut self, start: usize, new_char: char) {
-        assert!(start + new_char.len_utf8() <= self.len);
-        // This is pretty wasteful in that we're allocating for no point, but
-        // I think that is better than duplicating a bunch of code.
-        // It should be possible to view a &char as a &[u8] somehow, and then
-        // we can optimise this (FIXME).
-        self.replace_str(start, &new_char.to_string()[..]);
-    }
-
-    pub fn replace_str(&mut self, start: usize, new_str: &str) {
-        assert!(start + new_str.len() <= self.len);
-        self.root.replace(start, new_str);
-    }
 
     // Note, this is not necessarily cheap.
     pub fn col_for_src_loc(&self, src_loc: usize) -> usize {
@@ -205,25 +145,6 @@ impl Rope {
         match self.root.col_for_src_loc(src_loc) {
             Search::Done(c) | Search::Continue(c) => c
         }
-    }
-
-    pub fn slice(&self, Range { start, end }: Range<usize>) -> RopeSlice {
-        // This could be true for two cases
-        //    1. The Rope is empty (start == end == self.len == 0)
-        //    2. Attempting to slice the end of the rope (start == end == self.len)
-        if start == end {
-            return RopeSlice::empty();
-        }
-
-        debug_assert!(end > start && start <= self.len && end <= self.len);
-
-        let mut result = RopeSlice::empty();
-        self.root.find_slice(start, end, &mut result);
-        result
-    }
-
-    pub fn full_slice(&self) -> RopeSlice {
-        self.slice(0..self.len)
     }
 
     pub fn src_slice(&self, Range { start, end }: Range<usize>) -> RopeSlice {
@@ -235,15 +156,6 @@ impl Rope {
         let mut result = RopeSlice::empty();
         self.root.find_src_slice(start, end, &mut result);
         result
-    }
-
-    pub fn chars(&self) -> RopeChars {
-        RopeChars {
-            data: self.full_slice(),
-            cur_node: 0,
-            cur_byte: 0,
-            abs_byte: 0,
-        }
     }
 }
 


### PR DESCRIPTION
This moves the two rope variants into a ropes module. The old import
paths have been maintained by re-exporting.

This patch also extracts the common methods from the Rope impls to a
macro. This lets us write shared methods once, rather than have to
duplicate for both variants.
